### PR TITLE
feat: enable dark mode by default

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
Adds `dark` class to the html element to enable dark background by default.

Closes #2

Generated with [Claude Code](https://claude.ai/code)